### PR TITLE
Oozie client installation fails for java_version

### DIFF
--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/params.py
@@ -137,6 +137,7 @@ oozie_env_sh_template = config['configurations']['oozie-env']['content']
 oracle_driver_jar_name = "ojdbc6.jar"
 
 java_home = config['hostLevelParams']['java_home']
+java_version = int(config['hostLevelParams']['java_version'])
 oozie_metastore_user_name = config['configurations']['oozie-site']['oozie.service.JPAService.jdbc.username']
 oozie_metastore_user_passwd = default("/configurations/oozie-site/oozie.service.JPAService.jdbc.password","")
 oozie_jdbc_connection_url = default("/configurations/oozie-site/oozie.service.JPAService.jdbc.url", "")


### PR DESCRIPTION
Oozie client installation fails as Params.py doesn't have java_version while it's to be expanded in oozie-env.sh template.
