### PR TITLE
Kafka Sink build fails because of jmxtools.jar 1.2.1 and jmxri.jar 1.2.1

### DIFF
--- a/ambari-metrics/ambari-metrics-kafka-sink/pom.xml
+++ b/ambari-metrics/ambari-metrics-kafka-sink/pom.xml
@@ -126,6 +126,11 @@ limitations under the License.
       <version>0.8.1.1</version>
     </dependency>
     <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.16</version>
+    </dependency>
+    <dependency>
       <groupId>com.yammer.metrics</groupId>
       <artifactId>metrics-core</artifactId>
       <version>2.2.0</version>


### PR DESCRIPTION
Kafka Sink build fails as jmxtools.jar 1.2.1 and jmxri.jar 1.2.1 are no longer available. Changing log4j version removes these dependencies.
